### PR TITLE
Added three new properties do make the plugin more versatile

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -52,6 +52,9 @@ var fontMagnitudes = {
 				settings: {
 					lowerLimit: 1,
 					upperLimit: 6,
+					diceAmount: 1,
+					median: false,
+					addValue: 0,
 					disableDF: false,
 					lastRoll: null,
 				},
@@ -91,10 +94,24 @@ var fontMagnitudes = {
 					return;
 				}
 				
-				var lastRoll = Math.floor(Math.random()*(handleObj.settings.upperLimit-handleObj.settings.lowerLimit+1)+handleObj.settings.lowerLimit);
-				if(!lastRoll && lastRoll !== 0){
-					lastRoll = null;
+				rolls = [];
+				lastRoll = 0;
+				for (let i = 0; i < handleObj.settings.diceAmount; i++)
+				{
+					rolls.push(Math.floor(Math.random()*(handleObj.settings.upperLimit-handleObj.settings.lowerLimit+1)+handleObj.settings.lowerLimit));
 				}
+				
+				if (handleObj.settings.median) {
+					rolls = rolls.sort();
+					len = rolls.length;
+					mid = Math.ceil(len / 2);
+					lastRoll = len % 2 == 0 ? rolls[mid] : rolls[mid - 1];
+				}
+				else {
+					rolls.forEach(function(value, index, array) { lastRoll += value; });
+				}
+				
+				lastRoll += handleObj.settings.addValue;
 				
 				console.log("Rolled a: "+lastRoll);
 				
@@ -121,6 +138,15 @@ var fontMagnitudes = {
 					if(settings.hasOwnProperty('upperLimit')){
 						handleObj.settings.upperLimit = parseInt(settings["upperLimit"]) || 6;
 					}
+					if(settings.hasOwnProperty('diceAmount')){
+						handleObj.settings.diceAmount = parseInt(settings["diceAmount"]) || 1;
+					}
+					if(settings.hasOwnProperty('median')){
+						handleObj.settings.median = Boolean(settings["median"]) || false;
+					}
+					if(settings.hasOwnProperty('addValue')){
+						handleObj.settings.addValue = parseInt(settings["addValue"]) || 0;
+					}
 					if(settings.hasOwnProperty('disableDF')){
 						handleObj.settings.disableDF = Boolean(settings["disableDF"]) || false;
 					}
@@ -139,6 +165,9 @@ var fontMagnitudes = {
 						{
 							lowerLimit: handleObj.settings.lowerLimit,
 							upperLimit: handleObj.settings.upperLimit,
+							diceAmount: handleObj.settings.diceAmount,
+							median: handleObj.settings.median,
+							addValue: handleObj.settings.addValue,
 							disableDF: handleObj.settings.disableDF,
 						},
 						this.type
@@ -152,6 +181,18 @@ var fontMagnitudes = {
 						const val = parseInt(jsonObj.payload['upperLimit']) || 6;
 						handleObj.settings.upperLimit = val;
 					}
+					if (jsonObj.payload.hasOwnProperty('diceAmount')) {
+						const val = parseInt(jsonObj.payload['diceAmount']) || 1;
+						handleObj.settings.diceAmount = val;
+					}
+					if (jsonObj.payload.hasOwnProperty('median')) {
+						const val = Boolean(jsonObj.payload['median']) || false;
+						handleObj.settings.median = val;
+					}
+					if (jsonObj.payload.hasOwnProperty('addValue')) {
+						const val = parseInt(jsonObj.payload['addValue']) || 0;
+						handleObj.settings.addValue = val;
+					}					
 					if (jsonObj.payload.hasOwnProperty('disableDF')) {
 						const val = Boolean(jsonObj.payload['disableDF']) || false;
 						handleObj.settings.disableDF = val;
@@ -162,10 +203,13 @@ var fontMagnitudes = {
 						handleObj.settings.lowerLimit = handleObj.settings.upperLimit;
 						handleObj.settings.upperLimit = temp;
 					}
-					
+	
 					diceAction.updateSettings(context, {
 						lowerLimit: handleObj.settings.lowerLimit,
 						upperLimit: handleObj.settings.upperLimit,
+						diceAmount: handleObj.settings.diceAmount,
+						median: handleObj.settings.median,
+						addValue: handleObj.settings.addValue,
 						disableDF: handleObj.settings.disableDF,
 					});
 				}

--- a/propertyinspector/index.html
+++ b/propertyinspector/index.html
@@ -22,6 +22,19 @@
 				<summary>Limits are inclusive</summary>
 			</details>
 		</div>
+		<div class="sdpi-item">
+			<div class="sdpi-item-label">Amount of dice</div>
+			<input inputmode="numeric" pattern="[1-9]*" type="number" class="sdpi-item-value" id="diceAmount" onchange="sendValueToPlugin(event.target.value, 'diceAmount')" placeholder="1">
+		</div>
+		<div type="checkbox" class="sdpi-item">
+			<div class="sdpi-item-label">Median</div>
+			<input class="sdpi-item-value" id="median" type="checkbox" value="left" onclick="sendValueToPlugin(event.target.checked, 'median')">
+			<label for="median"><span></span></label>
+		</div>
+		<div class="sdpi-item">
+			<div class="sdpi-item-label">Add value</div>
+			<input inputmode="numeric" pattern="[0-9]*" type="number" class="sdpi-item-value" id="addValue" onchange="sendValueToPlugin(event.target.value, 'addValue')" placeholder="0">
+		</div>	
 		<div type="checkbox" class="sdpi-item">
 			<div class="sdpi-item-label">Disable Dice Faces</div>
 			<input class="sdpi-item-value" id="disableDF" type="checkbox" value="left" onclick="sendValueToPlugin(event.target.checked, 'disableDF')">
@@ -61,6 +74,9 @@
 			lowerLimit: null,
 			upperLimit: null,
 			disableDF: null,
+			diceAmount: null,
+			median: null,
+			addValue: null,
 		}
 
 		$SD.on('connected', (jsonObj) => connected(jsonObj));
@@ -76,6 +92,18 @@
 				if (jsonObj.payload.settings.hasOwnProperty('upperLimit')) {
 					console.log("Got upper limit value: "+jsonObj.payload.settings.upperLimit);
 					elements.upperLimit.value = jsonObj.payload.settings.upperLimit;
+				}		
+				if (jsonObj.payload.settings.hasOwnProperty('diceAmount')) {
+					console.log("Got diceAmount value: "+jsonObj.payload.settings.diceAmount);
+					elements.diceAmount.value = jsonObj.payload.settings.diceAmount;
+				}
+				if (jsonObj.payload.settings.hasOwnProperty('median')) {
+					console.log("Got median value: "+jsonObj.payload.settings.median);
+					elements.median.checked = jsonObj.payload.settings.median;
+				}
+				if (jsonObj.payload.settings.hasOwnProperty('addValue')) {
+					console.log("Got addValue value: "+jsonObj.payload.settings.addValue);
+					elements.addValue.value = jsonObj.payload.settings.addValue;
 				}
 				if (jsonObj.payload.settings.hasOwnProperty('disableDF')) {
 					console.log("Got disableDF value: "+jsonObj.payload.settings.disableDF);
@@ -90,6 +118,18 @@
 				if (jsonObj.payload.hasOwnProperty('upperLimit')) {
 					console.log("Got upper limit value: "+jsonObj.payload.upperLimit);
 					elements.upperLimit.value = jsonObj.payload.upperLimit;
+				}
+				if (jsonObj.payload.hasOwnProperty('diceAmount')) {
+					console.log("Got diceAmount value: "+jsonObj.payload.diceAmount);
+					elements.diceAmount.value = jsonObj.payload.diceAmount;
+				}
+				if (jsonObj.payload.hasOwnProperty('addValue')) {
+					console.log("Got addValue value: "+jsonObj.payload.addValue);
+					elements.addValue.value = jsonObj.payload.addValue;
+				}
+				if (jsonObj.payload.hasOwnProperty('median')) {
+					console.log("Got median value: "+jsonObj.payload.median);
+					elements.median.checked = jsonObj.payload.median;
 				}
 				if (jsonObj.payload.hasOwnProperty('disableDF')) {
 					console.log("Got disableDF value: "+jsonObj.payload.disableDF);
@@ -106,6 +146,9 @@
 
 			elements.lowerLimit = document.querySelector("#lowerLimit");
 			elements.upperLimit = document.querySelector("#upperLimit");
+			elements.diceAmount = document.querySelector("#diceAmount");
+			elements.median = document.querySelector("#median");
+			elements.addValue = document.querySelector("#addValue");
 			elements.disableDF = document.querySelector("#disableDF");
 			
 			const btOpen = document.querySelector("#btOpenFontAwesome");


### PR DESCRIPTION
- Added diceAmount property to roll multiple dice. By default the results are added, but the user can enable the new median property to only let the median value count (if dice amount is even: the higher of the two middle values).
- Added addValue property which is plainly added/subtracted from the rolled value.